### PR TITLE
Corriger les bugs dans le projet pricer intégration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ lazy val domain: Project     = (project in file("modules/02-domain"))
   .dependsOn(core % "test->test;compile->compile")
 
 lazy val new_pricer: Project = (project in file("modules/03-new_pricer"))
+  .enablePlugins(PlayScala)
   .settings(commonPlaySettings: _*)
   .dependsOn(core % "test->test;compile->compile", domain)
 

--- a/modules/03-new_pricer/build.sbt
+++ b/modules/03-new_pricer/build.sbt
@@ -1,3 +1,0 @@
-scalaSource in Test := { (baseDirectory in Test)(_ / "test") }.value
-
-scalaSource in Compile := { (baseDirectory in Compile)(_ / "app") }.value


### PR DESCRIPTION
C'est pour corriger ce bug : 
 Error injecting constructor, com.typesafe.config.ConfigException$Missing

Quand on tente de faire un test d'intégration pour créer un serveur et utiliser Configuration